### PR TITLE
chore: sync workflow templates

### DIFF
--- a/docs/SETUP_CHECKLIST.md
+++ b/docs/SETUP_CHECKLIST.md
@@ -8,7 +8,7 @@ configuration** and will fail silently if any element is missing.
 > before keepalive started functioning correctly. The lessons learned are encoded
 > in this checklist.
 
-> **See also**: [Consumer Repo Maintenance Guide](../ops/CONSUMER_REPO_MAINTENANCE.md)
+> **See also**: [Consumer Repo Maintenance Guide](https://github.com/stranske/Workflows/blob/main/docs/ops/CONSUMER_REPO_MAINTENANCE.md)
 > for debugging issues across multiple repos.
 
 ---

--- a/scripts/langchain/task_decomposer.py
+++ b/scripts/langchain/task_decomposer.py
@@ -345,10 +345,11 @@ def _normalize_subtasks(
     audit still balances.
     """
     parts = _collect_cleaned_parts(sub_tasks)
+    task_parts = [part for part in parts if not is_elision_sentinel(part)]
     # Only expand the mechanical triple when the input was effectively a single
     # task; multiple parts already represent a decomposition and must not be
     # tripled again (that 3xN fan-out is what ballooned issues).
-    allow_triple = len(parts) == 1
+    allow_triple = len(task_parts) == 1
 
     normalized: list[str] = []
     for cleaned in parts:

--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -177,8 +177,9 @@ def _detect_local_project_modules() -> set[str]:
             # Check for packages (directories with __init__.py)
             if item.is_dir() and (item / "__init__.py").exists():
                 detected.add(item.name)
-            # Check for standalone .py modules (but not in root .)
-            elif source_dir != Path(".") and item.suffix == ".py":
+            # Check for standalone .py modules, including root-level modules
+            # such as adapter.py in small consumer repos.
+            elif item.suffix == ".py":
                 detected.add(item.stem)
 
     return detected

--- a/scripts/validate_run_contract.py
+++ b/scripts/validate_run_contract.py
@@ -150,15 +150,16 @@ def _validate_consumer(
 
     # Try each declared schema; the document conforms if it matches at least one
     # of the ingested schema shapes (e.g. an evidence-object/v1 object).
+    unknown = [
+        t for t in ingests if t not in INGEST_SCHEMA_FILES and t not in INGEST_CONVENTION_ONLY
+    ]
+    for tok in unknown:
+        report.fail(f"unknown ingest schema token '{tok}'", "ingests")
+
     schema_tokens = [t for t in ingests if t in INGEST_SCHEMA_FILES]
     if not schema_tokens:
         # Only convention-only ingests (e.g. identity-map-conventions): nothing
         # to schema-validate; presence of a declared ingest is enough.
-        unknown = [
-            t for t in ingests if t not in INGEST_SCHEMA_FILES and t not in INGEST_CONVENTION_ONLY
-        ]
-        for tok in unknown:
-            report.fail(f"unknown ingest schema token '{tok}'", "ingests")
         return report
 
     per_schema_errors: dict[str, list[str]] = {}
@@ -277,6 +278,7 @@ def missing_envelope_report(registry: dict[str, Any], repo: str, run_json: Path)
     report = Report(repo=repo, role=entry.get("role", "") if entry else "")
     is_active_participant = entry is not None and entry.get("status") in EMITTING_STATUSES
     if is_active_participant:
+        assert entry is not None
         report.fail(
             f"{repo} is an active backplane participant "
             f"(role={entry.get('role')!r}, status={entry.get('status')!r}) "
@@ -325,7 +327,11 @@ def main(argv: list[str] | None = None) -> int:
     if envelope is None:
         report = missing_envelope_report(registry, args.repo, args.run_json)
     else:
-        manifest = _load_json(args.manifest) if args.manifest else None
+        try:
+            manifest = _load_json(args.manifest) if args.manifest else None
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"ERROR: cannot load artifact manifest: {exc}", file=sys.stderr)
+            return 2
         report = validate_envelope(
             envelope=envelope,
             schema_dir=args.schema_dir,


### PR DESCRIPTION
## Sync Summary

### Files Updated
- sync_test_dependencies.py: Syncs test dependency pins - required by reusable CI workflow
- task_decomposer.py: Task decomposer - breaks large issues into sub-tasks
- validate_run_contract.py: Validates a repo's emitted run-contract/v1 run envelope (producer/bridge) or ingested satellite object (consumer) against the canonical Workflows schemas + opt-in participant registry. Offline/deterministic; opt-in skip for non-participants. Synced so participants can validate locally and the reusable conformance gate can invoke it.
- SETUP_CHECKLIST.md: Consumer repo setup checklist. Includes the default_workflow_permissions=write step in section 3.3.1 that prevents a Gate startup_failure on fresh consumers (see #2157). Synced so it no longer drifts across the fleet.

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `6c97b27fb653923bd430cdd0f35ffdc27d00d95f`
**Template hash:** `6a0f6d3526b5`
**Sync branch:** `sync/workflows-6a0f6d3526b5`
**Consumer repo:** `stranske/Ready`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Ready","source_repository":"stranske/Workflows","source_sha":"6c97b27fb653923bd430cdd0f35ffdc27d00d95f","template_hash":"6a0f6d3526b5","sync_branch":"sync/workflows-6a0f6d3526b5","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"26802089424","run_attempt":"1","changes_count":4} -->