### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/workflows/maint-76-claude-code-review.yml
+++ b/.github/workflows/maint-76-claude-code-review.yml
@@ -188,7 +188,7 @@ jobs:
       - name: Run Claude Code Review
         id: claude
         continue-on-error: true
-        uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1 # v1
+        uses: anthropics/claude-code-action@593d7a5c4e0073569f74772c2b7b64c30ec14707 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: '*'

--- a/tools/embedding_provider.py
+++ b/tools/embedding_provider.py
@@ -105,6 +105,7 @@ class EmbeddingProvider(ABC):
 
     def supports_model(self, model: str | None) -> bool:
         """Return True if the provider can serve the requested model."""
+        del model
         return True
 
     def supports_capabilities(self, required: set[str]) -> bool:


### PR DESCRIPTION
## Sync Summary

### Files Updated
- maint-76-claude-code-review.yml: Claude Code review (opt-in) - runs only on labeled PRs or manual dispatch
- embedding_provider.py: Embedding provider registry used by synced semantic matching helpers

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `61c42acf24b637bace75be202f7e91f5588750ba`
**Template hash:** `45d602c4679f`
**Sync branch:** `sync/workflows-45d602c4679f`
**Consumer repo:** `stranske/Ready`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Ready","source_repository":"stranske/Workflows","source_sha":"61c42acf24b637bace75be202f7e91f5588750ba","template_hash":"45d602c4679f","sync_branch":"sync/workflows-45d602c4679f","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"27199283514","run_attempt":"1","changes_count":2} -->