### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/workflows/maint-76-claude-code-review.yml
+++ b/.github/workflows/maint-76-claude-code-review.yml
@@ -188,7 +188,7 @@ jobs:
       - name: Run Claude Code Review
         id: claude
         continue-on-error: true
-        uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1 # v1
+        uses: anthropics/claude-code-action@593d7a5c4e0073569f74772c2b7b64c30ec14707 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: '*'

--- a/tools/embedding_provider.py
+++ b/tools/embedding_provider.py
@@ -103,7 +103,7 @@ class EmbeddingProvider(ABC):
         """Return True if this provider is a non-LLM fallback."""
         return False
 
-    def supports_model(self, model: str | None) -> bool:
+    def supports_model(self, model: str | None) -> bool:  # noqa: ARG002
         """Return True if the provider can serve the requested model."""
         return True
 


### PR DESCRIPTION
## Sync Summary

### Files Updated
- maint-76-claude-code-review.yml: Claude Code review (opt-in) - runs only on labeled PRs or manual dispatch
- embedding_provider.py: Embedding provider registry used by synced semantic matching helpers

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `476290c36aed3e2138298ba6fcb571368eeeac08`
**Template hash:** `d738852fc429`
**Sync branch:** `sync/workflows-d738852fc429`
**Consumer repo:** `stranske/Ready`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Ready","source_repository":"stranske/Workflows","source_sha":"476290c36aed3e2138298ba6fcb571368eeeac08","template_hash":"d738852fc429","sync_branch":"sync/workflows-d738852fc429","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"27212059376","run_attempt":"1","changes_count":2} -->